### PR TITLE
@types/spotify-apiを正しい利用形式に修正

### DIFF
--- a/front/app/components/Search.tsx
+++ b/front/app/components/Search.tsx
@@ -18,6 +18,7 @@ import useQueryTracks from "./hooks/useQueryTracks"
 import useArtistParams from "./hooks/useArtistParams"
 import useRecommend from "./hooks/useRecommend"
 import useReTrackParams from "./hooks/useReTrackParams"
+import { MultipleArtistResponse, MultipleAlbumResponse } from "@types/spotify-api"
 
 interface SearchProps{
   token : string;
@@ -35,8 +36,8 @@ interface SelectedTrackProps{
 interface SetItemResultProps{
   id: string;
   name: string;
-  artists: string|any;
-  album: string|any;
+  artists: MultipleArtistResponse[]; //1つだけ取得する場合はSingleArtistResponse;
+  album: MultipleAlbumResponse[]; //1つだけ取得する場合はSingleAlbumResponse; []がいらないことに注意
   popularity: number;
   preview_url: string;
 }
@@ -71,7 +72,7 @@ interface SelectedRecommendProps{
 interface SetLookRecommendProps{
     id: string;
     name: string;
-    album: string|any;
+  album: MultipleAlbumResponse[];
     popularity: number;
     preview_url: string;
 }


### PR DESCRIPTION
node_modulesを参照しながら、おそらく正しいであろう形式に書き直してみました。

確認お願いします。